### PR TITLE
feat: enable to select collections as components in problems picker

### DIFF
--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -233,10 +233,9 @@ const LibraryAuthoringPage = ({
 
   const activeTypeFilters = {
     components: 'type = "library_block"',
-    collections: 'type = "collection"',
     units: 'block_type = "unit"',
   };
-  if (activeKey !== ContentType.home) {
+  if (activeKey !== ContentType.home && activeKey !== ContentType.collections) {
     extraFilter.push(activeTypeFilters[activeKey]);
   }
 

--- a/src/library-authoring/LibraryAuthoringPage.tsx
+++ b/src/library-authoring/LibraryAuthoringPage.tsx
@@ -38,7 +38,7 @@ import {
 } from '../search-manager';
 import LibraryContent from './LibraryContent';
 import { LibrarySidebar } from './library-sidebar';
-import { useComponentPickerContext } from './common/context/ComponentPickerContext';
+import { useComponentPickerContext, CollectionIndexProvider } from './common/context/ComponentPickerContext';
 import { useLibraryContext } from './common/context/LibraryContext';
 import { SidebarBodyComponentId, useSidebarContext } from './common/context/SidebarContext';
 import { allLibraryPageTabs, ContentType, useLibraryRoutes } from './routes';
@@ -284,38 +284,40 @@ const LibraryAuthoringPage = ({
             extraFilter={extraFilter}
             overrideTypesFilter={overrideTypesFilter}
           >
-            <SubHeader
-              title={<SubHeaderTitle title={libraryData.title} />}
-              subtitle={!componentPickerMode ? intl.formatMessage(messages.headingSubtitle) : undefined}
-              breadcrumbs={breadcumbs}
-              headerActions={<HeaderActions />}
-              hideBorder
-            />
-            <Tabs
-              variant="tabs"
-              activeKey={activeKey}
-              onSelect={handleTabChange}
-              className="my-3"
-            >
-              {visibleTabsToRender}
-            </Tabs>
-            <ActionRow className="my-3">
-              <SearchKeywordsField className="mr-3" />
-              <FilterByTags />
-              {!(insideCollections || insideUnits) && <FilterByBlockType />}
-              <LibraryFilterByPublished key={
-                // It is necessary to re-render `LibraryFilterByPublished` every time `FilterByBlockType`
-                // appears or disappears, this is because when the menu is opened it is rendered
-                // in a previous state, causing an inconsistency in its position.
-                // By changing the key we can re-render the component.
-                !(insideCollections || insideUnits) ? 'filter-published-1' : 'filter-published-2'
-              }
+            <CollectionIndexProvider>
+              <SubHeader
+                title={<SubHeaderTitle title={libraryData.title} />}
+                subtitle={!componentPickerMode ? intl.formatMessage(messages.headingSubtitle) : undefined}
+                breadcrumbs={breadcumbs}
+                headerActions={<HeaderActions />}
+                hideBorder
               />
-              <ClearFiltersButton />
-              <ActionRow.Spacer />
-              <SearchSortWidget />
-            </ActionRow>
-            <LibraryContent contentType={activeKey} />
+              <Tabs
+                variant="tabs"
+                activeKey={activeKey}
+                onSelect={handleTabChange}
+                className="my-3"
+              >
+                {visibleTabsToRender}
+              </Tabs>
+              <ActionRow className="my-3">
+                <SearchKeywordsField className="mr-3" />
+                <FilterByTags />
+                {!(insideCollections || insideUnits) && <FilterByBlockType />}
+                <LibraryFilterByPublished key={
+                  // It is necessary to re-render `LibraryFilterByPublished` every time `FilterByBlockType`
+                  // appears or disappears, this is because when the menu is opened it is rendered
+                  // in a previous state, causing an inconsistency in its position.
+                  // By changing the key we can re-render the component.
+                  !(insideCollections || insideUnits) ? 'filter-published-1' : 'filter-published-2'
+                }
+                />
+                <ClearFiltersButton />
+                <ActionRow.Spacer />
+                <SearchSortWidget />
+              </ActionRow>
+              <LibraryContent contentType={activeKey} />
+            </CollectionIndexProvider>
           </SearchContextProvider>
         </Container>
         {!componentPickerMode && <StudioFooterSlot containerProps={{ size: undefined }} />}

--- a/src/library-authoring/LibraryContent.tsx
+++ b/src/library-authoring/LibraryContent.tsx
@@ -43,6 +43,17 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
   const { openCreateCollectionModal } = useLibraryContext();
   const { openAddContentSidebar, openComponentInfoSidebar } = useSidebarContext();
 
+  /**
+   * Filter collections on the frontend to display only collection cards in the Collections tab.
+   * This approach is used instead of backend filtering to ensure that all components (including those
+   * within collections) remain available in the 'hits' array. This is necessary for the component
+   * selection workflow when adding components to xblocks by choosing the while collection in Collections tab.
+   * Note: LibraryAuthoringPage.tsx has been modified to skip backend filtering for this purpose.
+   */
+  const filteredHits = contentType === ContentType.collections
+    ? hits.filter((hit) => hit.type === 'collection')
+    : hits;
+
   useEffect(() => {
     if (usageKey) {
       openComponentInfoSidebar(usageKey);
@@ -76,7 +87,7 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
 
   return (
     <div className="library-cards-grid">
-      {hits.map((contentHit) => {
+      {filteredHits.map((contentHit) => {
         const CardComponent = LibraryItemCard[contentHit.type] || ComponentCard;
 
         return <CardComponent key={contentHit.id} hit={contentHit} />;

--- a/src/library-authoring/LibraryContent.tsx
+++ b/src/library-authoring/LibraryContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { LoadingSpinner } from '../generic/Loading';
 import { useSearchContext } from '../search-manager';
 import { NoComponents, NoSearchResults } from './EmptyStates';
@@ -50,9 +50,12 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
    * selection workflow when adding components to xblocks by choosing the whole collection in Collections tab.
    * Note: LibraryAuthoringPage.tsx has been modified to skip backend filtering for this purpose.
    */
-  const filteredHits = contentType === ContentType.collections
-    ? hits.filter((hit) => hit.type === 'collection')
-    : hits;
+  const filteredHits = useMemo(
+    () => (contentType === ContentType.collections
+      ? hits.filter((hit) => hit.type === 'collection')
+      : hits),
+    [hits, contentType],
+  );
 
   useEffect(() => {
     if (usageKey) {

--- a/src/library-authoring/LibraryContent.tsx
+++ b/src/library-authoring/LibraryContent.tsx
@@ -47,7 +47,7 @@ const LibraryContent = ({ contentType = ContentType.home }: LibraryContentProps)
    * Filter collections on the frontend to display only collection cards in the Collections tab.
    * This approach is used instead of backend filtering to ensure that all components (including those
    * within collections) remain available in the 'hits' array. This is necessary for the component
-   * selection workflow when adding components to xblocks by choosing the while collection in Collections tab.
+   * selection workflow when adding components to xblocks by choosing the whole collection in Collections tab.
    * Note: LibraryAuthoringPage.tsx has been modified to skip backend filtering for this purpose.
    */
   const filteredHits = contentType === ContentType.collections

--- a/src/library-authoring/__mocks__/library-search.json
+++ b/src/library-authoring/__mocks__/library-search.json
@@ -67,6 +67,7 @@
         },
         {
           "display_name": "Collection 2",
+          "block_id": "col2",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 58",
           "id": 2,
           "type": "collection",
@@ -99,6 +100,7 @@
         },
         {
           "display_name": "Collection 3",
+          "block_id": "col3",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 57",
           "id": 3,
           "type": "collection",
@@ -131,6 +133,7 @@
         },
         {
           "display_name": "Collection 4",
+          "block_id": "col4",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 56",
           "id": 4,
           "type": "collection",
@@ -163,6 +166,7 @@
         },
         {
           "display_name": "Collection 5",
+          "block_id": "col5",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 55",
           "id": 5,
           "type": "collection",
@@ -195,6 +199,7 @@
         },
         {
           "display_name": "Collection 6",
+          "block_id": "col6",
           "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque et mi ac nisi accumsan imperdiet vitae at odio. Vivamus tempor nec lorem eget lacinia. Vivamus efficitur lacus non dapibus porta. Nulla venenatis luctus nisi id posuere. Sed sollicitudin magna a sem ultrices accumsan. Praesent volutpat tortor vitae luctus rutrum. Integer. Descrition 54",
           "id": 6,
           "type": "collection",

--- a/src/library-authoring/collections/LibraryCollectionComponents.tsx
+++ b/src/library-authoring/collections/LibraryCollectionComponents.tsx
@@ -4,7 +4,6 @@ import { useSearchContext } from '../../search-manager';
 import messages from './messages';
 import { useSidebarContext } from '../common/context/SidebarContext';
 import LibraryContent from '../LibraryContent';
-import { ContentType } from '../routes';
 
 const LibraryCollectionComponents = () => {
   const { totalHits: componentCount, isFiltered } = useSearchContext();
@@ -25,7 +24,7 @@ const LibraryCollectionComponents = () => {
   return (
     <Stack direction="vertical" gap={3}>
       <h3 className="text-gray">Content ({componentCount})</h3>
-      <LibraryContent contentType={ContentType.collections} />
+      <LibraryContent />
     </Stack>
   );
 };

--- a/src/library-authoring/collections/LibraryCollectionPage.tsx
+++ b/src/library-authoring/collections/LibraryCollectionPage.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../search-manager';
 import { SubHeaderTitle } from '../LibraryAuthoringPage';
 import { useCollection, useContentLibrary } from '../data/apiHooks';
-import { useComponentPickerContext } from '../common/context/ComponentPickerContext';
+import { useComponentPickerContext, CollectionIndexProvider } from '../common/context/ComponentPickerContext';
 import { useLibraryContext } from '../common/context/LibraryContext';
 import { SidebarBodyComponentId, useSidebarContext } from '../common/context/SidebarContext';
 import messages from './messages';
@@ -208,22 +208,24 @@ const LibraryCollectionPage = () => {
           <SearchContextProvider
             extraFilter={extraFilter}
           >
-            <SubHeader
-              title={<SubHeaderTitle title={collectionData.title} />}
-              breadcrumbs={breadcrumbs}
-              headerActions={<HeaderActions />}
-              hideBorder
-            />
-            <ActionRow className="my-3">
-              <SearchKeywordsField className="mr-3" />
-              <FilterByTags />
-              <FilterByBlockType />
-              <LibraryFilterByPublished />
-              <ClearFiltersButton />
-              <ActionRow.Spacer />
-              <SearchSortWidget />
-            </ActionRow>
-            <LibraryCollectionComponents />
+            <CollectionIndexProvider>
+              <SubHeader
+                title={<SubHeaderTitle title={collectionData.title} />}
+                breadcrumbs={breadcrumbs}
+                headerActions={<HeaderActions />}
+                hideBorder
+              />
+              <ActionRow className="my-3">
+                <SearchKeywordsField className="mr-3" />
+                <FilterByTags />
+                <FilterByBlockType />
+                <LibraryFilterByPublished />
+                <ClearFiltersButton />
+                <ActionRow.Spacer />
+                <SearchSortWidget />
+              </ActionRow>
+              <LibraryCollectionComponents />
+            </CollectionIndexProvider>
           </SearchContextProvider>
         </Container>
         {!componentPickerMode && <StudioFooterSlot containerProps={{ size: undefined }} />}

--- a/src/library-authoring/common/context/ComponentPickerContext.tsx
+++ b/src/library-authoring/common/context/ComponentPickerContext.tsx
@@ -9,9 +9,20 @@ import {
 export interface SelectedComponent {
   usageKey: string;
   blockType: string;
+  collectionKeys?: string[];
 }
 
-export type ComponentSelectedEvent = (selectedComponent: SelectedComponent) => void;
+export type CollectionStatus = 'selected' | 'indeterminate';
+
+export interface SelectedCollection {
+  key: string;
+  status: CollectionStatus;
+}
+
+export type ComponentSelectedEvent = (
+  selectedComponent: SelectedComponent,
+  collectionComponents?: SelectedComponent[] | number
+) => void;
 export type ComponentSelectionChangedEvent = (selectedComponents: SelectedComponent[]) => void;
 
 type NoComponentPickerType = {
@@ -21,6 +32,7 @@ type NoComponentPickerType = {
    */
   onComponentSelected?: never;
   selectedComponents?: never;
+  selectedCollections?: never;
   addComponentToSelectedComponents?: never;
   removeComponentFromSelectedComponents?: never;
   restrictToLibrary?: never;
@@ -30,6 +42,7 @@ type ComponentPickerSingleType = {
   componentPickerMode: 'single';
   onComponentSelected: ComponentSelectedEvent;
   selectedComponents?: never;
+  selectedCollections?: never;
   addComponentToSelectedComponents?: never;
   removeComponentFromSelectedComponents?: never;
   restrictToLibrary: boolean;
@@ -39,6 +52,7 @@ type ComponentPickerMultipleType = {
   componentPickerMode: 'multiple';
   onComponentSelected?: never;
   selectedComponents: SelectedComponent[];
+  selectedCollections: SelectedCollection[];
   addComponentToSelectedComponents: ComponentSelectedEvent;
   removeComponentFromSelectedComponents: ComponentSelectedEvent;
   restrictToLibrary: boolean;
@@ -85,16 +99,105 @@ export const ComponentPickerProvider = ({
   onChangeComponentSelection,
 }: ComponentPickerProviderProps) => {
   const [selectedComponents, setSelectedComponents] = useState<SelectedComponent[]>([]);
+  const [selectedCollections, setSelectedCollections] = useState<SelectedCollection[]>([]);
+
+  /**
+   * Updates the selectedCollections state based on how many components are selected.
+   * @param collectionKey - The key of the collection to update
+   * @param selectedCount - Number of components currently selected in the collection
+   * @param totalCount - Total number of components in the collection
+   */
+  const updateCollectionStatus = useCallback((
+    collectionKey: string,
+    selectedCount: number,
+    totalCount: number,
+  ) => {
+    setSelectedCollections((prevSelectedCollections) => {
+      const filteredCollections = prevSelectedCollections.filter(
+        (collection) => collection.key !== collectionKey,
+      );
+
+      if (selectedCount === 0) {
+        return filteredCollections;
+      }
+      if (selectedCount >= totalCount) {
+        return [...filteredCollections, { key: collectionKey, status: 'selected' as CollectionStatus }];
+      }
+      return [...filteredCollections, { key: collectionKey, status: 'indeterminate' as CollectionStatus }];
+    });
+  }, []);
+
+  /**
+   * Finds the common collection key between a component and selected components.
+   */
+  const findCommonCollectionKey = useCallback((
+    componentKeys: string[] | undefined,
+    components: SelectedComponent[],
+  ): string | undefined => {
+    if (!componentKeys?.length || !components.length) {
+      return undefined;
+    }
+
+    for (const component of components) {
+      const commonKey = component.collectionKeys?.find((key) => componentKeys.includes(key));
+      if (commonKey) {
+        return commonKey;
+      }
+    }
+
+    return undefined;
+  }, []);
 
   const addComponentToSelectedComponents = useCallback<ComponentSelectedEvent>((
     selectedComponent: SelectedComponent,
+    collectionComponents?: SelectedComponent[] | number,
   ) => {
+    const componentsToAdd = Array.isArray(collectionComponents) && collectionComponents.length
+      ? collectionComponents
+      : [selectedComponent];
+
     setSelectedComponents((prevSelectedComponents) => {
-      // istanbul ignore if: this should never happen
-      if (prevSelectedComponents.some((component) => component.usageKey === selectedComponent.usageKey)) {
+      const existingKeys = new Set(prevSelectedComponents.map((c) => c.usageKey));
+      const newComponents = componentsToAdd.filter((c) => !existingKeys.has(c.usageKey));
+
+      if (newComponents.length === 0) {
         return prevSelectedComponents;
       }
-      const newSelectedComponents = [...prevSelectedComponents, selectedComponent];
+
+      const newSelectedComponents = [...prevSelectedComponents, ...newComponents];
+
+      // Handle collection selection (when selecting entire collection)
+      if (Array.isArray(collectionComponents) && collectionComponents.length) {
+        updateCollectionStatus(
+          selectedComponent.usageKey,
+          collectionComponents.length,
+          collectionComponents.length,
+        );
+      }
+
+      // Handle individual component selection (with total count)
+      if (typeof collectionComponents === 'number') {
+        const componentCollectionKeys = selectedComponent.collectionKeys;
+        const selectedCollectionComponents = newSelectedComponents.filter(
+          (component) => component.collectionKeys?.some(
+            (key) => componentCollectionKeys?.includes(key),
+          ),
+        );
+
+        const collectionKey = findCommonCollectionKey(
+          componentCollectionKeys,
+          selectedCollectionComponents,
+        );
+
+        if (collectionKey) {
+          updateCollectionStatus(
+            collectionKey,
+            selectedCollectionComponents.length,
+            collectionComponents,
+          );
+        }
+      }
+
       onChangeComponentSelection?.(newSelectedComponents);
       return newSelectedComponents;
     });
@@ -102,15 +205,41 @@ export const ComponentPickerProvider = ({
 
   const removeComponentFromSelectedComponents = useCallback<ComponentSelectedEvent>((
     selectedComponent: SelectedComponent,
+    collectionComponents?: SelectedComponent[] | number,
   ) => {
+    const componentsToRemove = Array.isArray(collectionComponents) && collectionComponents.length
+      ? collectionComponents
+      : [selectedComponent];
+    const usageKeysToRemove = new Set(componentsToRemove.map((c) => c.usageKey));
+
     setSelectedComponents((prevSelectedComponents) => {
-      // istanbul ignore if: this should never happen
-      if (!prevSelectedComponents.some((component) => component.usageKey === selectedComponent.usageKey)) {
-        return prevSelectedComponents;
-      }
       const newSelectedComponents = prevSelectedComponents.filter(
-        (component) => component.usageKey !== selectedComponent.usageKey,
+        (component) => !usageKeysToRemove.has(component.usageKey),
       );
+
+      if (typeof collectionComponents === 'number') {
+        const componentCollectionKeys = selectedComponent.collectionKeys;
+        const collectionKey = findCommonCollectionKey(componentCollectionKeys, componentsToRemove);
+
+        if (collectionKey) {
+          const remainingCollectionComponents = newSelectedComponents.filter(
+            (component) => component.collectionKeys?.includes(collectionKey),
+          );
+          updateCollectionStatus(
+            collectionKey,
+            remainingCollectionComponents.length,
+            collectionComponents,
+          );
+        }
+      } else {
+        // Fallback: remove collections that have no remaining components
+        setSelectedCollections((prevSelectedCollections) => prevSelectedCollections.filter(
+          (collection) => newSelectedComponents.some(
+            (component) => component.collectionKeys?.includes(collection.key),
+          ),
+        ));
+      }
+
       onChangeComponentSelection?.(newSelectedComponents);
       return newSelectedComponents;
     });
@@ -128,6 +257,7 @@ export const ComponentPickerProvider = ({
         return {
           componentPickerMode,
           restrictToLibrary,
+          selectedCollections,
           selectedComponents,
           addComponentToSelectedComponents,
           removeComponentFromSelectedComponents,
@@ -143,7 +273,7 @@ export const ComponentPickerProvider = ({
     addComponentToSelectedComponents,
     removeComponentFromSelectedComponents,
     selectedComponents,
-    onChangeComponentSelection,
+    selectedCollections,
   ]);
 
   return (

--- a/src/library-authoring/common/context/ComponentPickerContext.tsx
+++ b/src/library-authoring/common/context/ComponentPickerContext.tsx
@@ -5,7 +5,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { ContentHit, useSearchContext } from 'search-manager';
+import { ContentHit, useSearchContext } from '../../../search-manager';
 
 /**
  * Provides pre-computed collection indexing data to avoid repeated computation.

--- a/src/library-authoring/common/context/ComponentPickerContext.tsx
+++ b/src/library-authoring/common/context/ComponentPickerContext.tsx
@@ -5,6 +5,8 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { ContentHit } from 'search-manager';
+import { useSearchContext } from 'search-manager/SearchManager';
 
 export interface SelectedComponent {
   usageKey: string;
@@ -19,9 +21,14 @@ export interface SelectedCollection {
   status: CollectionStatus;
 }
 
+export interface CollectionData {
+  components: SelectedComponent[];
+  affectedCollectionSizes: Map<string, number>;
+}
+
 export type ComponentSelectedEvent = (
   selectedComponent: SelectedComponent,
-  collectionComponents?: SelectedComponent[] | number
+  collectionComponents?: CollectionData | Map<string, number>
 ) => void;
 export type ComponentSelectionChangedEvent = (selectedComponents: SelectedComponent[]) => void;
 
@@ -89,6 +96,87 @@ type ComponentPickerProviderProps = {
 } & ComponentPickerProps;
 
 /**
+ * Pre-computed collection indexing data for O(1) lookups
+ */
+export interface CollectionIndexData {
+  /** Map: collectionKey → components in that collection */
+  collectionToComponents: Map<string, SelectedComponent[]>;
+  /** Map: componentUsageKey → collection keys it belongs to */
+  componentToCollections: Map<string, string[]>;
+  /** Map: collectionKey → Map of all affected collections with their sizes */
+  collectionToAffectedSizes: Map<string, Map<string, number>>;
+  /** Map: collectionKey → total component count (for quick size lookup) */
+  collectionSizes: Map<string, number>;
+}
+
+/**
+ * Hook to build indexing maps for collections and components.
+ * Pre-computes all relationships for O(1) lookups during selection operations.
+ * @param hits - Search hits from which to build the indexes
+ * @returns Pre-computed collection index data
+ */
+export const useCollectionIndexing = (
+  hits: ReturnType<typeof useSearchContext>['hits'],
+): CollectionIndexData => useMemo(() => {
+  const collectionToComponents = new Map<string, SelectedComponent[]>();
+  const componentToCollections = new Map<string, string[]>();
+  const collectionSizes = new Map<string, number>();
+
+  // First pass: build basic indexes
+  hits.forEach((hit) => {
+    if (hit.type === 'library_block') {
+      const collectionKeys = (hit as ContentHit).collections?.key ?? [];
+
+      // Index component → collections mapping
+      if (hit.usageKey) {
+        componentToCollections.set(hit.usageKey, collectionKeys);
+      }
+
+      // Index collection → components mapping
+      collectionKeys.forEach((collectionKey: string) => {
+        if (!collectionToComponents.has(collectionKey)) {
+          collectionToComponents.set(collectionKey, []);
+        }
+        collectionToComponents.get(collectionKey)!.push({
+          usageKey: hit.usageKey,
+          blockType: hit.blockType,
+          collectionKeys,
+        });
+      });
+    }
+  });
+
+  // Second pass: compute collection sizes
+  collectionToComponents.forEach((components, collectionKey) => {
+    collectionSizes.set(collectionKey, components.length);
+  });
+
+  // Third pass: pre-compute affected collections for each collection
+  const collectionToAffectedSizes = new Map<string, Map<string, number>>();
+  collectionToComponents.forEach((components, collectionKey) => {
+    const affectedSizes = new Map<string, number>();
+
+    // For each component in this collection, find all collections it belongs to
+    components.forEach((component) => {
+      component.collectionKeys?.forEach((affectedKey) => {
+        if (!affectedSizes.has(affectedKey)) {
+          affectedSizes.set(affectedKey, collectionSizes.get(affectedKey) ?? 0);
+        }
+      });
+    });
+
+    collectionToAffectedSizes.set(collectionKey, affectedSizes);
+  });
+
+  return {
+    collectionToComponents,
+    componentToCollections,
+    collectionToAffectedSizes,
+    collectionSizes,
+  };
+}, [hits]);
+
+/**
  * React component to provide `ComponentPickerContext`
  */
 export const ComponentPickerProvider = ({
@@ -101,59 +189,13 @@ export const ComponentPickerProvider = ({
   const [selectedComponents, setSelectedComponents] = useState<SelectedComponent[]>([]);
   const [selectedCollections, setSelectedCollections] = useState<SelectedCollection[]>([]);
 
-  /**
-   * Updates the selectedCollections state based on how many components are selected.
-   * @param collectionKey - The key of the collection to update
-   * @param selectedCount - Number of components currently selected in the collection
-   * @param totalCount - Total number of components in the collection
-   */
-  const updateCollectionStatus = useCallback((
-    collectionKey: string,
-    selectedCount: number,
-    totalCount: number,
-  ) => {
-    setSelectedCollections((prevSelectedCollections) => {
-      const filteredCollections = prevSelectedCollections.filter(
-        (collection) => collection.key !== collectionKey,
-      );
-
-      if (selectedCount === 0) {
-        return filteredCollections;
-      }
-      if (selectedCount >= totalCount) {
-        return [...filteredCollections, { key: collectionKey, status: 'selected' as CollectionStatus }];
-      }
-      return [...filteredCollections, { key: collectionKey, status: 'indeterminate' as CollectionStatus }];
-    });
-  }, []);
-
-  /**
-   * Finds the common collection key between a component and selected components.
-   */
-  const findCommonCollectionKey = useCallback((
-    componentKeys: string[] | undefined,
-    components: SelectedComponent[],
-  ): string | undefined => {
-    if (!componentKeys?.length || !components.length) {
-      return undefined;
-    }
-
-    for (const component of components) {
-      const commonKey = component.collectionKeys?.find((key) => componentKeys.includes(key));
-      if (commonKey) {
-        return commonKey;
-      }
-    }
-
-    return undefined;
-  }, []);
-
   const addComponentToSelectedComponents = useCallback<ComponentSelectedEvent>((
     selectedComponent: SelectedComponent,
-    collectionComponents?: SelectedComponent[] | number,
+    collectionComponents?: CollectionData | Map<string, number>,
   ) => {
-    const componentsToAdd = Array.isArray(collectionComponents) && collectionComponents.length
-      ? collectionComponents
+    const isCollectionSelection = collectionComponents && 'components' in collectionComponents;
+    const componentsToAdd = isCollectionSelection
+      ? collectionComponents.components
       : [selectedComponent];
 
     setSelectedComponents((prevSelectedComponents) => {
@@ -166,49 +208,55 @@ export const ComponentPickerProvider = ({
 
       const newSelectedComponents = [...prevSelectedComponents, ...newComponents];
 
-      // Handle collection selection (when selecting entire collection)
-      if (Array.isArray(collectionComponents) && collectionComponents.length) {
-        updateCollectionStatus(
-          selectedComponent.usageKey,
-          collectionComponents.length,
-          collectionComponents.length,
-        );
-      }
+      const collectionSizes = isCollectionSelection
+        ? collectionComponents.affectedCollectionSizes
+        : collectionComponents;
 
-      // Handle individual component selection (with total count)
-      if (typeof collectionComponents === 'number') {
-        const componentCollectionKeys = selectedComponent.collectionKeys;
-        const selectedCollectionComponents = newSelectedComponents.filter(
-          (component) => component.collectionKeys?.some(
-            (key) => componentCollectionKeys?.includes(key),
-          ),
-        );
+      if (collectionSizes instanceof Map && collectionSizes.size > 0) {
+        const selectedByCollection = new Map<string, number>();
 
-        const collectionKey = findCommonCollectionKey(
-          componentCollectionKeys,
-          selectedCollectionComponents,
-        );
+        newSelectedComponents.forEach((component) => {
+          component.collectionKeys?.forEach((key) => {
+            if (collectionSizes.has(key)) {
+              selectedByCollection.set(key, (selectedByCollection.get(key) ?? 0) + 1);
+            }
+          });
+        });
 
-        if (collectionKey) {
-          updateCollectionStatus(
-            collectionKey,
-            selectedCollectionComponents.length,
-            collectionComponents,
+        // Batch update all collection statuses
+        setSelectedCollections((prevSelectedCollections) => {
+          const collectionMap = new Map(
+            prevSelectedCollections.map((c) => [c.key, c]),
           );
-        }
+
+          collectionSizes.forEach((totalCount, collectionKey) => {
+            const selectedCount = selectedByCollection.get(collectionKey) ?? 0;
+
+            if (selectedCount === 0) {
+              collectionMap.delete(collectionKey);
+            } else if (selectedCount >= totalCount) {
+              collectionMap.set(collectionKey, { key: collectionKey, status: 'selected' });
+            } else {
+              collectionMap.set(collectionKey, { key: collectionKey, status: 'indeterminate' });
+            }
+          });
+
+          return Array.from(collectionMap.values());
+        });
       }
 
       onChangeComponentSelection?.(newSelectedComponents);
       return newSelectedComponents;
     });
-  }, []);
+  }, [onChangeComponentSelection]);
 
   const removeComponentFromSelectedComponents = useCallback<ComponentSelectedEvent>((
     selectedComponent: SelectedComponent,
-    collectionComponents?: SelectedComponent[] | number,
+    collectionComponents?: CollectionData | Map<string, number>,
   ) => {
-    const componentsToRemove = Array.isArray(collectionComponents) && collectionComponents.length
-      ? collectionComponents
+    const isCollectionSelection = collectionComponents && 'components' in collectionComponents;
+    const componentsToRemove = isCollectionSelection
+      ? collectionComponents.components
       : [selectedComponent];
     const usageKeysToRemove = new Set(componentsToRemove.map((c) => c.usageKey));
 
@@ -217,33 +265,48 @@ export const ComponentPickerProvider = ({
         (component) => !usageKeysToRemove.has(component.usageKey),
       );
 
-      if (typeof collectionComponents === 'number') {
-        const componentCollectionKeys = selectedComponent.collectionKeys;
-        const collectionKey = findCommonCollectionKey(componentCollectionKeys, componentsToRemove);
+      const collectionSizes = isCollectionSelection
+        ? collectionComponents.affectedCollectionSizes
+        : collectionComponents;
 
-        if (collectionKey) {
-          const remainingCollectionComponents = newSelectedComponents.filter(
-            (component) => component.collectionKeys?.includes(collectionKey),
+      if (collectionSizes instanceof Map && collectionSizes.size > 0) {
+        const selectedByCollection = new Map<string, number>();
+
+        // Only count components for collections we care about
+        newSelectedComponents.forEach((component) => {
+          component.collectionKeys?.forEach((key) => {
+            if (collectionSizes.has(key)) {
+              selectedByCollection.set(key, (selectedByCollection.get(key) ?? 0) + 1);
+            }
+          });
+        });
+
+        // Batch update all collection statuses
+        setSelectedCollections((prevSelectedCollections) => {
+          const collectionMap = new Map(
+            prevSelectedCollections.map((c) => [c.key, c]),
           );
-          updateCollectionStatus(
-            collectionKey,
-            remainingCollectionComponents.length,
-            collectionComponents,
-          );
-        }
-      } else {
-        // Fallback: remove collections that have no remaining components
-        setSelectedCollections((prevSelectedCollections) => prevSelectedCollections.filter(
-          (collection) => newSelectedComponents.some(
-            (component) => component.collectionKeys?.includes(collection.key),
-          ),
-        ));
+
+          collectionSizes.forEach((totalCount, collectionKey) => {
+            const selectedCount = selectedByCollection.get(collectionKey) ?? 0;
+
+            if (selectedCount === 0) {
+              collectionMap.delete(collectionKey);
+            } else if (selectedCount >= totalCount) {
+              collectionMap.set(collectionKey, { key: collectionKey, status: 'selected' });
+            } else {
+              collectionMap.set(collectionKey, { key: collectionKey, status: 'indeterminate' });
+            }
+          });
+
+          return Array.from(collectionMap.values());
+        });
       }
 
       onChangeComponentSelection?.(newSelectedComponents);
       return newSelectedComponents;
     });
-  }, []);
+  }, [onChangeComponentSelection]);
 
   const context = useMemo<ComponentPickerContextData>(() => {
     switch (componentPickerMode) {

--- a/src/library-authoring/common/context/ComponentPickerContext.tsx
+++ b/src/library-authoring/common/context/ComponentPickerContext.tsx
@@ -5,8 +5,12 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { ContentHit } from 'search-manager';
-import { useSearchContext } from 'search-manager/SearchManager';
+import { ContentHit, useSearchContext } from 'search-manager';
+
+/**
+ * Provides pre-computed collection indexing data to avoid repeated computation.
+ */
+const CollectionIndexContext = createContext<CollectionIndexData | undefined>(undefined);
 
 export interface SelectedComponent {
   usageKey: string;
@@ -175,6 +179,40 @@ export const useCollectionIndexing = (
     collectionSizes,
   };
 }, [hits]);
+
+type CollectionIndexProviderProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * React component to provide pre-computed collection indexing data.
+ * Must be rendered inside a SearchContextProvider.
+ * This provider ensures collection indexing is computed once and shared
+ * with all AddComponentWidget instances, avoiding O(n*m) complexity.
+ */
+export const CollectionIndexProvider = ({ children }: CollectionIndexProviderProps) => {
+  const { hits } = useSearchContext();
+  const collectionIndexData = useCollectionIndexing(hits);
+
+  return (
+    <CollectionIndexContext.Provider value={collectionIndexData}>
+      {children}
+    </CollectionIndexContext.Provider>
+  );
+};
+
+/**
+ * Hook to access pre-computed collection indexing data.
+ * Must be used within a CollectionIndexProvider.
+ * @returns CollectionIndexData with pre-computed maps
+ */
+export const useCollectionIndexContext = (): CollectionIndexData => {
+  const ctx = useContext(CollectionIndexContext);
+  if (ctx === undefined) {
+    throw new Error('useCollectionIndexContext must be used within a CollectionIndexProvider');
+  }
+  return ctx;
+};
 
 /**
  * React component to provide `ComponentPickerContext`

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -230,7 +230,7 @@ describe('<ComponentPicker />', () => {
     onChange.mockClear();
 
     // Select another component
-    fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[1]);
+    fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[7]);
     await waitFor(() => expect(onChange).toHaveBeenCalledWith([
       {
         usageKey: 'lb:Axim:TEST:html:571fe018-f3ce-45c9-8f53-5dafcb422fdd',

--- a/src/library-authoring/component-picker/ComponentPicker.test.tsx
+++ b/src/library-authoring/component-picker/ComponentPicker.test.tsx
@@ -230,6 +230,10 @@ describe('<ComponentPicker />', () => {
     onChange.mockClear();
 
     // Select another component
+    /**
+    * Due to collections have "Select" buttons as well, we need to target the 8th button in the list
+    * to select the second component in the search results, taking into account the `library-search.json` mock data.
+    */
     fireEvent.click(screen.queryAllByRole('button', { name: 'Select' })[7]);
     await waitFor(() => expect(onChange).toHaveBeenCalledWith([
       {

--- a/src/library-authoring/components/AddComponentWidget.tsx
+++ b/src/library-authoring/components/AddComponentWidget.tsx
@@ -1,20 +1,56 @@
+import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { Button } from '@openedx/paragon';
 import {
   AddCircleOutline,
   CheckBoxIcon,
+  IndeterminateCheckBox,
   CheckBoxOutlineBlank,
 } from '@openedx/paragon/icons';
 
-import { useComponentPickerContext } from '../common/context/ComponentPickerContext';
+import { ContentHit, useSearchContext } from '../../search-manager';
+import { SelectedComponent, useComponentPickerContext } from '../common/context/ComponentPickerContext';
 import messages from './messages';
 
 interface AddComponentWidgetProps {
   usageKey: string;
   blockType: string;
+  collectionKeys?: string[];
+  isCollection?: boolean;
 }
 
-const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) => {
+/**
+ * Builds an array of SelectedComponent from collection hits.
+ */
+const buildCollectionComponents = (
+  hits: ReturnType<typeof useSearchContext>['hits'],
+  collectionUsageKey: string,
+): SelectedComponent[] => hits
+  .filter((hit) => hit.type === 'library_block' && hit.collections?.key?.includes(collectionUsageKey))
+  .map((hit: ContentHit) => ({
+    usageKey: hit.usageKey,
+    blockType: hit.blockType,
+    collectionKeys: (hit as ContentHit).collections?.key,
+  }));
+
+/**
+ * Counts the number of hits that share a collection key with the given component.
+ */
+const countCollectionHits = (
+  hits: ReturnType<typeof useSearchContext>['hits'],
+  componentCollectionKey: string[] | undefined,
+): number => {
+  if (!componentCollectionKey?.length) {
+    return 0;
+  }
+  return hits.filter(
+    (hit) => (hit as ContentHit).collections?.key?.some((key) => componentCollectionKey.includes(key)),
+  ).length;
+};
+
+const AddComponentWidget = ({
+  usageKey, blockType, collectionKeys, isCollection,
+}: AddComponentWidgetProps) => {
   const intl = useIntl();
 
   const {
@@ -23,7 +59,21 @@ const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) =>
     addComponentToSelectedComponents,
     removeComponentFromSelectedComponents,
     selectedComponents,
+    selectedCollections,
   } = useComponentPickerContext();
+
+  const { hits } = useSearchContext();
+
+  const collectionData = useMemo(() => {
+    // When selecting a collection: retrieve all its components to enable bulk selection
+    if (isCollection) {
+      return buildCollectionComponents(hits, usageKey);
+    }
+    // When selecting an individual component: get the total count of components in its collection
+    // This count is used to determine if the entire collection should be marked as selected
+    const componentCollectionKey = (hits.find((hit) => hit.usageKey === usageKey) as ContentHit)?.collections?.key;
+    return countCollectionHits(hits, componentCollectionKey);
+  }, [hits, usageKey, isCollection]);
 
   // istanbul ignore if: this should never happen
   if (!usageKey) {
@@ -50,24 +100,37 @@ const AddComponentWidget = ({ usageKey, blockType }: AddComponentWidgetProps) =>
   }
 
   if (componentPickerMode === 'multiple') {
-    const isChecked = selectedComponents.some((component) => component.usageKey === usageKey);
+    const collectionStatus = selectedCollections.find((c) => c.key === usageKey)?.status;
+
+    const isChecked = isCollection
+      ? collectionStatus === 'selected'
+      : selectedComponents.some((component) => component.usageKey === usageKey);
+
+    const isIndeterminate = isCollection && collectionStatus === 'indeterminate';
+
+    const getIcon = () => {
+      if (isChecked) { return CheckBoxIcon; }
+      if (isIndeterminate) { return IndeterminateCheckBox; }
+      return CheckBoxOutlineBlank;
+    };
 
     const handleChange = () => {
-      const selectedComponent = {
+      const selectedComponent: SelectedComponent = {
         usageKey,
         blockType,
+        collectionKeys,
       };
       if (!isChecked) {
-        addComponentToSelectedComponents(selectedComponent);
+        addComponentToSelectedComponents(selectedComponent, collectionData);
       } else {
-        removeComponentFromSelectedComponents(selectedComponent);
+        removeComponentFromSelectedComponents(selectedComponent, collectionData);
       }
     };
 
     return (
       <Button
         variant="outline-primary"
-        iconBefore={isChecked ? CheckBoxIcon : CheckBoxOutlineBlank}
+        iconBefore={getIcon()}
         onClick={handleChange}
       >
         {intl.formatMessage(messages.componentPickerMultipleSelectTitle)}

--- a/src/library-authoring/components/AddComponentWidget.tsx
+++ b/src/library-authoring/components/AddComponentWidget.tsx
@@ -8,8 +8,13 @@ import {
   CheckBoxOutlineBlank,
 } from '@openedx/paragon/icons';
 
-import { ContentHit, useSearchContext } from '../../search-manager';
-import { SelectedComponent, useComponentPickerContext } from '../common/context/ComponentPickerContext';
+import { useSearchContext } from '../../search-manager';
+import {
+  SelectedComponent,
+  useComponentPickerContext,
+  useCollectionIndexing,
+} from '../common/context/ComponentPickerContext';
+
 import messages from './messages';
 
 interface AddComponentWidgetProps {
@@ -18,35 +23,6 @@ interface AddComponentWidgetProps {
   collectionKeys?: string[];
   isCollection?: boolean;
 }
-
-/**
- * Builds an array of SelectedComponent from collection hits.
- */
-const buildCollectionComponents = (
-  hits: ReturnType<typeof useSearchContext>['hits'],
-  collectionUsageKey: string,
-): SelectedComponent[] => hits
-  .filter((hit) => hit.type === 'library_block' && hit.collections?.key?.includes(collectionUsageKey))
-  .map((hit: ContentHit) => ({
-    usageKey: hit.usageKey,
-    blockType: hit.blockType,
-    collectionKeys: (hit as ContentHit).collections?.key,
-  }));
-
-/**
- * Counts the number of hits that share a collection key with the given component.
- */
-const countCollectionHits = (
-  hits: ReturnType<typeof useSearchContext>['hits'],
-  componentCollectionKey: string[] | undefined,
-): number => {
-  if (!componentCollectionKey?.length) {
-    return 0;
-  }
-  return hits.filter(
-    (hit) => (hit as ContentHit).collections?.key?.some((key) => componentCollectionKey.includes(key)),
-  ).length;
-};
 
 const AddComponentWidget = ({
   usageKey, blockType, collectionKeys, isCollection,
@@ -63,17 +39,43 @@ const AddComponentWidget = ({
   } = useComponentPickerContext();
 
   const { hits } = useSearchContext();
+  const {
+    collectionToComponents,
+    componentToCollections,
+    collectionToAffectedSizes,
+    collectionSizes,
+  } = useCollectionIndexing(hits);
 
   const collectionData = useMemo(() => {
-    // When selecting a collection: retrieve all its components to enable bulk selection
     if (isCollection) {
-      return buildCollectionComponents(hits, usageKey);
+      return {
+        components: collectionToComponents.get(usageKey) ?? [],
+        affectedCollectionSizes: collectionToAffectedSizes.get(usageKey) ?? new Map<string, number>(),
+      };
     }
-    // When selecting an individual component: get the total count of components in its collection
-    // This count is used to determine if the entire collection should be marked as selected
-    const componentCollectionKey = (hits.find((hit) => hit.usageKey === usageKey) as ContentHit)?.collections?.key;
-    return countCollectionHits(hits, componentCollectionKey);
-  }, [hits, usageKey, isCollection]);
+
+    const componentCollectionKeys = componentToCollections.get(usageKey);
+    if (!componentCollectionKeys?.length) {
+      return new Map<string, number>();
+    }
+
+    const sizes = new Map<string, number>();
+    componentCollectionKeys.forEach((collectionKey) => {
+      const size = collectionSizes.get(collectionKey);
+      if (size !== undefined) {
+        sizes.set(collectionKey, size);
+      }
+    });
+
+    return sizes;
+  }, [
+    collectionToComponents,
+    componentToCollections,
+    collectionToAffectedSizes,
+    collectionSizes,
+    usageKey,
+    isCollection,
+  ]);
 
   // istanbul ignore if: this should never happen
   if (!usageKey) {
@@ -120,10 +122,19 @@ const AddComponentWidget = ({
         blockType,
         collectionKeys,
       };
+
+      const isCollectionData = isCollection && 'components' in collectionData;
+
       if (!isChecked) {
-        addComponentToSelectedComponents(selectedComponent, collectionData);
+        addComponentToSelectedComponents(
+          selectedComponent,
+          isCollectionData ? collectionData : collectionData as Map<string, number>,
+        );
       } else {
-        removeComponentFromSelectedComponents(selectedComponent, collectionData);
+        removeComponentFromSelectedComponents(
+          selectedComponent,
+          isCollectionData ? collectionData : collectionData as Map<string, number>,
+        );
       }
     };
 

--- a/src/library-authoring/components/AddComponentWidget.tsx
+++ b/src/library-authoring/components/AddComponentWidget.tsx
@@ -8,11 +8,10 @@ import {
   CheckBoxOutlineBlank,
 } from '@openedx/paragon/icons';
 
-import { useSearchContext } from '../../search-manager';
 import {
   SelectedComponent,
   useComponentPickerContext,
-  useCollectionIndexing,
+  useCollectionIndexContext,
 } from '../common/context/ComponentPickerContext';
 
 import messages from './messages';
@@ -38,13 +37,12 @@ const AddComponentWidget = ({
     selectedCollections,
   } = useComponentPickerContext();
 
-  const { hits } = useSearchContext();
   const {
     collectionToComponents,
     componentToCollections,
     collectionToAffectedSizes,
     collectionSizes,
-  } = useCollectionIndexing(hits);
+  } = useCollectionIndexContext();
 
   const collectionData = useMemo(() => {
     if (isCollection) {

--- a/src/library-authoring/components/CollectionCard.tsx
+++ b/src/library-authoring/components/CollectionCard.tsx
@@ -20,6 +20,7 @@ import { ToastContext } from '../../generic/toast-context';
 import { useDeleteCollection, useRestoreCollection } from '../data/apiHooks';
 import DeleteModal from '../../generic/delete-modal/DeleteModal';
 import messages from './messages';
+import AddComponentWidget from './AddComponentWidget';
 
 type CollectionMenuProps = {
   hit: CollectionHit,
@@ -155,9 +156,16 @@ const CollectionCard = ({ hit } : CollectionCardProps) => {
       description={description}
       tags={tags}
       numChildren={numChildrenCount}
-      actions={!componentPickerMode && (
+      actions={(
         <ActionRow>
-          <CollectionMenu hit={hit} />
+          {componentPickerMode ? (
+            <AddComponentWidget
+              isCollection
+              usageKey={collectionId}
+              blockType={itemType}
+            />
+          ) : (
+            <CollectionMenu hit={hit} />)}
         </ActionRow>
       )}
       onSelect={openCollection}

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -26,6 +26,7 @@ const ComponentCard = ({ hit }: ComponentCardProps) => {
     formatted,
     tags,
     usageKey,
+    collections,
     publishStatus,
   } = hit;
   const componentDescription: string = (
@@ -56,7 +57,11 @@ const ComponentCard = ({ hit }: ComponentCardProps) => {
       actions={(
         <ActionRow>
           {componentPickerMode ? (
-            <AddComponentWidget usageKey={usageKey} blockType={blockType} />
+            <AddComponentWidget
+              usageKey={usageKey}
+              blockType={blockType}
+              collectionKeys={collections?.key ?? undefined}
+            />
           ) : (
             <ComponentMenu usageKey={usageKey} />
           )}

--- a/src/library-authoring/components/ComponentCard.tsx
+++ b/src/library-authoring/components/ComponentCard.tsx
@@ -60,7 +60,7 @@ const ComponentCard = ({ hit }: ComponentCardProps) => {
             <AddComponentWidget
               usageKey={usageKey}
               blockType={blockType}
-              collectionKeys={collections?.key ?? undefined}
+              collectionKeys={collections?.key}
             />
           ) : (
             <ComponentMenu usageKey={usageKey} />

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -310,6 +310,58 @@ export async function fetchSearchResults({
   };
 }
 
+/* eslint-disable no-await-in-loop */
+export async function fetchAllSearchResults(
+  params: FetchSearchParams,
+): Promise<{
+  hits: HitType[];
+  totalHits: number;
+  blockTypes: Record<string, number>;
+  problemTypes: Record<string, number>;
+  publishStatus: Record<string, number>;
+}> {
+  const allHits: HitType[] = [];
+  const limit = params.limit ?? 20;
+
+  let offset = 0;
+  let nextOffset: number | undefined;
+
+  // Facets + totals only need to be read once (from the first page)
+  let totalHits = 0;
+  let blockTypes: Record<string, number> = {};
+  let problemTypes: Record<string, number> = {};
+  let publishStatus: Record<string, number> = {};
+
+  do {
+    const page = await fetchSearchResults({
+      ...params,
+      offset,
+      limit,
+    });
+
+    allHits.push(...page.hits);
+
+    if (offset === 0) {
+      totalHits = page.totalHits;
+      blockTypes = page.blockTypes;
+      problemTypes = page.problemTypes;
+      publishStatus = page.publishStatus;
+    }
+
+    nextOffset = page.nextOffset;
+    offset = nextOffset ?? offset;
+  } while (nextOffset !== undefined);
+
+  return {
+    hits: allHits,
+    totalHits,
+    blockTypes,
+    problemTypes,
+    publishStatus,
+  };
+}
+/* eslint-enable no-await-in-loop */
+
 /**
  * Fetch the block types facet distribution for the search results.
  */

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -310,29 +310,28 @@ export async function fetchSearchResults({
   };
 }
 
-/* eslint-disable no-await-in-loop */
 export async function fetchAllSearchResults(
   params: FetchSearchParams,
 ): Promise<{
-  hits: HitType[];
-  totalHits: number;
-  blockTypes: Record<string, number>;
-  problemTypes: Record<string, number>;
-  publishStatus: Record<string, number>;
-}> {
+    hits: HitType[];
+    totalHits: number;
+    blockTypes: Record<string, number>;
+    problemTypes: Record<string, number>;
+    publishStatus: Record<string, number>;
+  }> {
   const allHits: HitType[] = [];
-  const limit = params.limit ?? 20;
+  const limit = params.limit ?? 100;
 
   let offset = 0;
   let nextOffset: number | undefined;
 
-  // Facets + totals only need to be read once (from the first page)
   let totalHits = 0;
   let blockTypes: Record<string, number> = {};
   let problemTypes: Record<string, number> = {};
   let publishStatus: Record<string, number> = {};
 
   do {
+    // eslint-disable-next-line no-await-in-loop
     const page = await fetchSearchResults({
       ...params,
       offset,
@@ -360,7 +359,6 @@ export async function fetchAllSearchResults(
     publishStatus,
   };
 }
-/* eslint-enable no-await-in-loop */
 
 /**
  * Fetch the block types facet distribution for the search results.

--- a/src/search-manager/data/api.ts
+++ b/src/search-manager/data/api.ts
@@ -330,7 +330,9 @@ export async function fetchAllSearchResults(
   let problemTypes: Record<string, number> = {};
   let publishStatus: Record<string, number> = {};
 
-  do {
+  let hasNextPage = true;
+
+  while (hasNextPage) {
     // eslint-disable-next-line no-await-in-loop
     const page = await fetchSearchResults({
       ...params,
@@ -348,8 +350,19 @@ export async function fetchAllSearchResults(
     }
 
     nextOffset = page.nextOffset;
-    offset = nextOffset ?? offset;
-  } while (nextOffset !== undefined);
+
+    // Stop conditions
+    if (
+      nextOffset === undefined
+    || nextOffset <= offset
+    || allHits.length >= totalHits
+    ) {
+      hasNextPage = false;
+      break;
+    }
+
+    offset = nextOffset;
+  }
 
   return {
     hits: allHits,

--- a/src/search-manager/data/apiHooks.ts
+++ b/src/search-manager/data/apiHooks.ts
@@ -6,7 +6,7 @@ import {
   SearchSortOption,
   TAG_SEP,
   fetchAvailableTagOptions,
-  fetchSearchResults,
+  fetchAllSearchResults,
   fetchTagsThatMatchKeyword,
   getContentSearchConfig,
   fetchBlockTypes,
@@ -106,7 +106,7 @@ export const useContentSearchResults = ({
       if (client === undefined || indexName === undefined) {
         throw new Error('Required data unexpectedly undefined. Check "enable" condition of useQuery.');
       }
-      return fetchSearchResults({
+      return fetchAllSearchResults({
         client,
         extraFilter,
         indexName,

--- a/src/search-manager/data/apiHooks.ts
+++ b/src/search-manager/data/apiHooks.ts
@@ -123,7 +123,6 @@ export const useContentSearchResults = ({
         limit,
       });
     },
-    getNextPageParam: (lastPage) => lastPage.nextOffset,
     // Avoid flickering results when user is typing... keep old results until new is available.
     keepPreviousData: true,
     refetchOnWindowFocus: false, // This doesn't need to be refreshed when the user switches back to this tab.


### PR DESCRIPTION
This pull request refactors and optimizes how collections and their components are indexed and filtered in the library authoring UI. The main improvements are the introduction of a centralized collection indexing context for O(1) lookups, frontend filtering for the Collections tab to enable more flexible workflows, and associated updates to component interfaces and context providers. These changes improve performance and maintainability, especially when working with large sets of collections and components.

**Collection indexing and context improvements:**

- Introduced `CollectionIndexProvider` and related hooks/types in `ComponentPickerContext.tsx` to precompute and share collection/component relationships and sizes across the UI, avoiding repeated computation and improving performance. This includes new interfaces and a context for accessing the precomputed data. [[1]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R8-R36) [[2]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R102-R216)
- Updated imports and wrapped relevant page components (`LibraryAuthoringPage` and `LibraryCollectionPage`) with `CollectionIndexProvider` to ensure all children have access to the precomputed collection index data. [[1]](diffhunk://#diff-b607a6130d15e58997aa9499ad9dfa67e094b17d966b5750e86f5bb7cadaaa73L41-R41) [[2]](diffhunk://#diff-b607a6130d15e58997aa9499ad9dfa67e094b17d966b5750e86f5bb7cadaaa73R287) [[3]](diffhunk://#diff-b607a6130d15e58997aa9499ad9dfa67e094b17d966b5750e86f5bb7cadaaa73R320) [[4]](diffhunk://#diff-b7e614f0ee3a5e74cbf83016d5b03598485806ecd28e4d172733a3aeba195038L32-R32) [[5]](diffhunk://#diff-b7e614f0ee3a5e74cbf83016d5b03598485806ecd28e4d172733a3aeba195038R211) [[6]](diffhunk://#diff-b7e614f0ee3a5e74cbf83016d5b03598485806ecd28e4d172733a3aeba195038R228)

**Filtering and content display logic:**

- Moved filtering of collections in the Collections tab from the backend to the frontend in `LibraryContent.tsx`, ensuring all components remain available in the search hits for selection workflows. Adjusted the filtering logic in `LibraryAuthoringPage.tsx` accordingly. [[1]](diffhunk://#diff-2dbf7689e2e92c3beb107328d77b772213ee3f75445da9e4a92d2c06ffaabf32R46-R56) [[2]](diffhunk://#diff-2dbf7689e2e92c3beb107328d77b772213ee3f75445da9e4a92d2c06ffaabf32L79-R90) [[3]](diffhunk://#diff-b607a6130d15e58997aa9499ad9dfa67e094b17d966b5750e86f5bb7cadaaa73L236-R238)
- Updated `LibraryCollectionComponents.tsx` to use the default `LibraryContent` (with frontend filtering) instead of passing a collections-specific content type. [[1]](diffhunk://#diff-c4f8166a9c029983da982be4085d4536ce7f9e836f248493704b180d0a6b3a3eL7) [[2]](diffhunk://#diff-c4f8166a9c029983da982be4085d4536ce7f9e836f248493704b180d0a6b3a3eL28-R27)

**Type and interface enhancements:**

- Extended selection-related interfaces to support collections, including new types for selected collections, collection status, and events that handle both components and collections. [[1]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R8-R36) [[2]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R46) [[3]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R56) [[4]](diffhunk://#diff-56a2caa7a3a665d1608eada6aec67fa79983bf8879d0b1a90d4eb719b3725e11R66)

**Test data updates:**

- Added `block_id` fields to mock collection data in `library-search.json` to better reflect the updated data structures and support new indexing logic. [[1]](diffhunk://#diff-923384689ec224772d7555023d1eab8ae7a2c90e930727e972540b8c49534cb0R70) [[2]](diffhunk://#diff-923384689ec224772d7555023d1eab8ae7a2c90e930727e972540b8c49534cb0R103) [[3]](diffhunk://#diff-923384689ec224772d7555023d1eab8ae7a2c90e930727e972540b8c49534cb0R136) [[4]](diffhunk://#diff-923384689ec224772d7555023d1eab8ae7a2c90e930727e972540b8c49534cb0R169) [[5]](diffhunk://#diff-923384689ec224772d7555023d1eab8ae7a2c90e930727e972540b8c49534cb0R202)

### How to test
Make sure you have a collection in your Libraries ( http://apps.local.openedx.io:2001/authoring/libraries ) with questions in it
1. Have a Teak environment
2. Mount this MFE and switch to this branch
3. Install https://github.com/eduNEXT-collab/xblock-exam-question-bank in the CMS
4. Go to the Authoring MFE ( http://apps.local.openedx.io:2001/authoring/ ), create a new course or use any existing one, go to `Settings > Advanced Settings` and add ` "examquestionbank"` to the list of `Advanced module list`
5. Go to the content outline and access a unit
6. Click `Advanced` in the component selector and add an `Exam Question Bank`
7. Click `Add Problems` and select a collection; it should be selected and deselected properly, and once you click `Add Selected Components`, they should be displayed in the xblock as will be shown in the following screencast

### Screencast

[Screencast from 09-01-26 14:40:43.webm](https://github.com/user-attachments/assets/fd476fb4-0fe3-4160-96a5-441bfc756b36)
